### PR TITLE
Surface final answers and show original question

### DIFF
--- a/demo_ui/backend/main.py
+++ b/demo_ui/backend/main.py
@@ -1103,6 +1103,7 @@ async def compare(request: CompareRequest):
                 "budget": request.budget,
                 "run_id": run_id,
                 "use_case": request.use_case,
+                "question_type": question_type,
             }
         }
 

--- a/demo_ui/frontend/index.html
+++ b/demo_ui/frontend/index.html
@@ -467,12 +467,6 @@ gcloud auth application-default login</div>
                 <button class="iw-back-btn" onclick="iwGoBack(4)">← Back to Configure</button>
                 <h3 class="iw-step-title">Results</h3>
 
-                <!-- Expected Answer (for curated prompts) -->
-                <div id="iwExpectedAnswer" class="iw-expected-answer hidden">
-                    <div class="iw-expected-label">Expected Answer</div>
-                    <div class="iw-expected-content" id="iwExpectedContent"></div>
-                </div>
-
                 <!-- Response panes -->
                 <div id="iwResultsArea"></div>
 

--- a/demo_ui/frontend/interactive-demo.css
+++ b/demo_ui/frontend/interactive-demo.css
@@ -678,14 +678,6 @@
 }
 
 /* ===== EXPECTED ANSWER ===== */
-.iw-expected-answer {
-    padding: 16px 20px;
-    background: var(--bg-primary);
-    border: 2px solid var(--success);
-    border-left: 4px solid var(--success);
-    margin-bottom: 24px;
-}
-
 .iw-expected-label {
     font-size: 11px;
     font-weight: 700;
@@ -693,12 +685,6 @@
     letter-spacing: 0.06em;
     color: var(--success);
     margin-bottom: 8px;
-}
-
-.iw-expected-content {
-    font-size: 14px;
-    color: var(--text-primary);
-    line-height: 1.6;
 }
 
 /* ===== EXPANDABLE SECTIONS ===== */
@@ -743,6 +729,8 @@
 
 .iw-expandable.expanded .iw-expand-content {
     display: block;
+    max-height: 300px;
+    overflow-y: auto;
     animation: iwFadeIn 0.3s ease-out;
 }
 
@@ -815,6 +803,75 @@
     margin-bottom: 20px;
     color: var(--danger);
     font-size: 14px;
+}
+
+/* ===== QUESTION DISPLAY ===== */
+.iw-question-display {
+    padding: 16px 20px;
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-left: 4px solid var(--primary);
+    margin-bottom: 20px;
+}
+
+.iw-question-label {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--primary);
+    margin-bottom: 8px;
+}
+
+.iw-question-text {
+    font-size: 14px;
+    color: var(--text-primary);
+    line-height: 1.6;
+}
+
+.iw-expected-inline {
+    margin-top: 10px;
+    padding-top: 10px;
+    border-top: 1px solid var(--border-color);
+    font-size: 13px;
+}
+
+.iw-expected-inline .iw-expected-label {
+    font-weight: 700;
+    color: var(--success);
+    margin-right: 6px;
+    margin-bottom: 0;
+}
+
+.iw-expected-inline .iw-expected-value {
+    color: var(--text-primary);
+    font-family: 'IBM Plex Mono', monospace;
+}
+
+/* ===== FINAL ANSWER CALLOUT ===== */
+.iw-final-answer {
+    padding: 14px 18px;
+    background: rgba(163, 190, 140, 0.08);
+    border: 1px solid rgba(163, 190, 140, 0.3);
+    border-left: 4px solid var(--success);
+    margin-bottom: 14px;
+}
+
+.iw-final-answer-label {
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--success);
+    margin-bottom: 6px;
+}
+
+.iw-final-answer-content {
+    font-size: 18px;
+    font-family: 'IBM Plex Mono', monospace;
+    font-weight: 600;
+    color: var(--text-primary);
+    line-height: 1.5;
 }
 
 /* ===== RESTART AREA ===== */


### PR DESCRIPTION
## Summary
- **Fixes #25**: Extracts final answers from math reasoning traces into a prominent callout box at the top of each result pane, so users don't have to scroll through long reasoning to find the answer
- **Fixes #26**: Displays the original question (and expected answer for curated prompts) above the results grid, so users retain context of what was asked
- Expandable sections (reasoning, traces, performance) now cap at 300px with scroll to keep the layout compact

## Test plan
- [ ] Run existing tests: `cd demo_ui && python -m pytest tests/` (110 pass)
- [ ] Interactive demo with a **math question** — verify "Final Answer" callout appears with extracted value, full reasoning in expandable
- [ ] Interactive demo with a **general question** — verify no "Final Answer" callout, response shown directly
- [ ] Curated question — verify expected answer appears inline below the question
- [ ] Custom question — verify question displays above results, no expected answer shown