### PR TITLE
Fix ITS token estimates and surface generation time

### DIFF
--- a/demo_ui/backend/main.py
+++ b/demo_ui/backend/main.py
@@ -871,18 +871,54 @@ async def run_its(
     # Build trace from the full result
     trace = build_trace(algorithm, result, tool_vote=tool_vote)
 
-    # Estimate token usage for ITS
-    # ITS algorithms typically make multiple calls (roughly proportional to budget)
-    # For outcome-based (best_of_n, self_consistency): budget calls
-    # For process-based: budget calls spread across steps
-    # This is an approximation since we don't have exact tracking within algorithms
+    # --- Estimated token usage for ITS ---
+    #
+    # WHY ESTIMATED: ITS algorithms call the LLM multiple times internally
+    # (via ainfer()), but the algorithm classes do not accumulate or return
+    # per-call token usage from litellm. Until the algorithm internals are
+    # updated to surface aggregated usage data, we estimate based on:
+    #
+    #   1. The baseline's actual token counts (from a single litellm call)
+    #   2. The number of candidates the algorithm produced
+    #   3. Algorithm-specific overhead (judge/PRM scoring calls)
+    #
+    # These estimates are marked with tokens_estimated=True in the response
+    # so the frontend can label them accordingly.
+    #
+    # WHAT IS ACTUAL vs ESTIMATED for ITS results:
+    #   - latency_ms:    ACTUAL (wall-clock around the full ainfer() call)
+    #   - input_tokens:  ESTIMATED (see formula below)
+    #   - output_tokens: ESTIMATED (see formula below)
+    #   - cost_usd:      ESTIMATED (derived from estimated tokens x pricing)
+    #
+    num_candidates = len(result.responses) if hasattr(result, 'responses') else budget
+
     if baseline_input_tokens > 0 and baseline_output_tokens > 0:
-        # Estimate: ITS makes ~budget calls, each similar to baseline
-        # Input stays similar, output may vary
-        estimated_input = baseline_input_tokens * budget
-        estimated_output = baseline_output_tokens * budget
+        # Base: assume each candidate uses roughly the same tokens as baseline
+        estimated_input = baseline_input_tokens * num_candidates
+        estimated_output = baseline_output_tokens * num_candidates
+
+        if algorithm == "best_of_n":
+            # Best-of-N also makes one LLM judge call per candidate to score
+            # it. The judge sees the candidate response (~baseline_output_tokens)
+            # plus a scoring prompt (~200 tokens), and produces a short score
+            # output (~50 tokens).
+            judge_input_per_call = baseline_output_tokens + 200
+            judge_output_per_call = 50
+            estimated_input += judge_input_per_call * num_candidates
+            estimated_output += judge_output_per_call * num_candidates
+        elif algorithm in ["beam_search", "particle_filtering", "entropic_particle_filtering", "particle_gibbs"]:
+            # Process-based algorithms make PRM scoring calls at each
+            # reasoning step. We use the actual step count from the result
+            # when available, otherwise fall back to budget * 4 as a rough
+            # average. Each PRM call uses ~150 input and ~30 output tokens.
+            if hasattr(result, 'steps_used_lst'):
+                prm_calls = sum(result.steps_used_lst)
+            else:
+                prm_calls = budget * 4
+            estimated_input += 150 * prm_calls
+            estimated_output += 30 * prm_calls
     else:
-        # Fallback: no estimation available
         estimated_input = 0
         estimated_output = 0
 
@@ -1094,6 +1130,7 @@ async def compare(request: CompareRequest):
                 cost_usd=its_cost if its_cost > 0 else None,
                 input_tokens=its_input_tokens if its_input_tokens > 0 else None,
                 output_tokens=its_output_tokens if its_output_tokens > 0 else None,
+                tokens_estimated=True,
                 trace=its_trace,
                 tool_calls=its_tool_calls if its_tool_calls else None,
             ),

--- a/demo_ui/backend/models.py
+++ b/demo_ui/backend/models.py
@@ -116,14 +116,39 @@ class ParticleGibbsTrace(BaseModel):
 
 
 class ResultDetail(BaseModel):
-    """Details of a single result (baseline or ITS)."""
+    """Details of a single result (baseline or ITS).
+
+    Metric accuracy by result type:
+      Baseline — latency, input_tokens, output_tokens, and cost_usd are all
+        actual values. Latency is wall-clock measured. Token counts come from
+        the litellm response usage object. Cost is calculated from actual
+        tokens and the model's configured pricing.
+      ITS — latency is actual (wall-clock). Token counts (input_tokens,
+        output_tokens) are *estimates* derived from the baseline token counts
+        multiplied by the number of candidates, plus algorithm-specific
+        overhead (judge calls for Best-of-N, PRM calls for process-based
+        algorithms). cost_usd is calculated from these estimated tokens and
+        is therefore also an estimate. The underlying ITS algorithm classes
+        do not currently surface per-call token usage; to get actual ITS
+        token counts, the algorithm internals would need to accumulate
+        litellm usage data across all internal LLM calls.
+
+    When tokens_estimated is True, the frontend prefixes token/cost values
+    with "~" and labels them "(est.)" to communicate this to users.
+    """
     answer: str = Field(..., description="The final answer text")
-    latency_ms: int = Field(..., description="Latency in milliseconds")
+    latency_ms: int = Field(..., description="Latency in milliseconds (actual wall-clock)")
     log_preview: str = Field(default="", description="Placeholder for step logs (future)")
     model_size: Optional[str] = Field(default=None, description="Model size (e.g., 'Large', 'Small')")
-    cost_usd: Optional[float] = Field(default=None, description="Cost in USD")
-    input_tokens: Optional[int] = Field(default=None, description="Number of input tokens")
-    output_tokens: Optional[int] = Field(default=None, description="Number of output tokens")
+    cost_usd: Optional[float] = Field(default=None, description="Cost in USD (estimated when tokens_estimated=True)")
+    input_tokens: Optional[int] = Field(default=None, description="Number of input tokens (estimated for ITS results)")
+    output_tokens: Optional[int] = Field(default=None, description="Number of output tokens (estimated for ITS results)")
+    tokens_estimated: bool = Field(
+        default=False,
+        description="Whether token counts are estimates. True for ITS results "
+        "(algorithms don't expose per-call usage), False for baseline results "
+        "(actual counts from litellm)."
+    )
     trace: Optional[dict] = Field(default=None, description="Algorithm trace data for visualization")
     tool_calls: Optional[list[ToolCall]] = Field(default=None, description="Tool calls made during execution")
 

--- a/demo_ui/frontend/guided-demo.js
+++ b/demo_ui/frontend/guided-demo.js
@@ -18,6 +18,12 @@
 // STATE
 // ============================================================
 
+function guidedFormatLatency(ms) {
+    if (ms == null) return 'N/A';
+    if (ms >= 1000) return (ms / 1000).toFixed(1) + 's';
+    return ms + 'ms';
+}
+
 const guidedDemoState = {
     goal: null,        // 'improve_performance' or 'match_frontier'
     method: null,      // 'self_consistency' or 'best_of_n'
@@ -253,9 +259,9 @@ function initGuidedWizard() {
         }
     });
 
-    // Hide old guided badge and back button
+    // Hide old guided badge and back button (new wizard has its own UI)
     const badge = document.getElementById('guidedDemoBadge');
-    if (badge) badge.style.display = 'none';
+    if (badge) { badge.classList.add('hidden'); badge.style.display = ''; }
 
     const backBtn = document.getElementById('wizardBackBtn');
     if (backBtn) backBtn.style.display = 'none';
@@ -591,7 +597,7 @@ function guidedBuildResponsePane(title, type, data) {
                     ${title}
                 </div>
                 <div class="guided-pane-badges">
-                    <span class="guided-pane-badge">${data.latency_ms}ms</span>
+                    <span class="guided-pane-badge">${guidedFormatLatency(data.latency_ms)}</span>
                     <span class="guided-pane-badge">${costFmt}</span>
                 </div>
             </div>

--- a/demo_ui/frontend/interactive-demo.css
+++ b/demo_ui/frontend/interactive-demo.css
@@ -635,6 +635,43 @@
     padding: 20px;
 }
 
+/* ===== RESPONSE TIME DISPLAY ===== */
+.iw-response-time {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    margin-bottom: 14px;
+    padding: 10px 14px;
+    background: var(--bg-tertiary);
+    border-left: 3px solid var(--primary);
+}
+
+.iw-response-time .response-time-value {
+    font-size: 22px;
+    font-weight: 700;
+    font-family: 'IBM Plex Mono', monospace;
+    color: var(--text-primary);
+}
+
+.iw-response-time .response-time-label {
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--text-tertiary);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+/* ===== ESTIMATE NOTE ===== */
+.iw-estimate-note {
+    margin-top: 10px;
+    padding: 8px 12px;
+    font-size: 11px;
+    line-height: 1.5;
+    color: var(--text-tertiary);
+    background: var(--bg-secondary);
+    border-left: 3px solid var(--text-tertiary);
+}
+
 .iw-pane-response {
     font-size: 14px;
     line-height: 1.7;

--- a/demo_ui/frontend/interactive-demo.js
+++ b/demo_ui/frontend/interactive-demo.js
@@ -18,6 +18,12 @@ function iwEscapeHtml(text) {
     return div.innerHTML;
 }
 
+function iwFormatLatency(ms) {
+    if (ms == null) return 'N/A';
+    if (ms >= 1000) return (ms / 1000).toFixed(1) + 's';
+    return ms + 'ms';
+}
+
 // ============================================================
 // STATE
 // ============================================================
@@ -616,8 +622,9 @@ function iwBuildResultPane(data, type, title, minCost, minLatency) {
     if (latency != null && latency <= minLatency) badges += '<span class="iw-pane-badge fastest">Fastest</span>';
 
     // Format cost
+    const isEstimated = !!data.tokens_estimated;
     const costFmt = cost != null
-        ? (cost < 0.0001 ? '$' + cost.toExponential(2) : '$' + cost.toFixed(4))
+        ? (isEstimated ? '~' : '') + (cost < 0.0001 ? '$' + cost.toExponential(2) : '$' + cost.toFixed(4))
         : 'N/A';
 
     // Response content
@@ -710,12 +717,16 @@ function iwBuildResultPane(data, type, title, minCost, minLatency) {
                 <div class="iw-pane-badges">${badges}</div>
             </div>
             <div class="iw-pane-body">
+                <div class="iw-response-time">
+                    <span class="response-time-value">${iwFormatLatency(latency)}</span>
+                    <span class="response-time-label">response time</span>
+                </div>
                 ${finalAnswerHtml}
                 <div class="iw-pane-response">${responseHtml}</div>
                 <div class="iw-pane-meta">
-                    <span class="iw-meta-tag"><span class="meta-label">Latency:</span><span class="meta-value">${latency != null ? latency + 'ms' : 'N/A'}</span></span>
-                    <span class="iw-meta-tag"><span class="meta-label">Cost:</span><span class="meta-value">${costFmt}</span></span>
-                    <span class="iw-meta-tag"><span class="meta-label">Tokens:</span><span class="meta-value">${(data.input_tokens || 0) + (data.output_tokens || 0)}</span></span>
+                    <span class="iw-meta-tag"><span class="meta-label">Latency:</span><span class="meta-value">${iwFormatLatency(latency)}</span></span>
+                    <span class="iw-meta-tag"><span class="meta-label">Cost${isEstimated ? ' (est.)' : ''}:</span><span class="meta-value">${costFmt}</span></span>
+                    <span class="iw-meta-tag"><span class="meta-label">Tokens${isEstimated ? ' (est.)' : ''}:</span><span class="meta-value">${isEstimated ? '~' : ''}${(data.input_tokens || 0) + (data.output_tokens || 0)}</span></span>
                 </div>
             </div>
             ${hasFullReasoning ? `
@@ -734,12 +745,13 @@ function iwBuildResultPane(data, type, title, minCost, minLatency) {
                 </button>
                 <div class="iw-expand-content">
                     <div style="display:grid; grid-template-columns:1fr 1fr; gap:8px; font-size:13px;">
-                        <span style="color:var(--text-tertiary)">Latency</span><span style="font-family:'IBM Plex Mono',monospace">${latency != null ? latency + 'ms' : 'N/A'}</span>
-                        <span style="color:var(--text-tertiary)">Cost</span><span style="font-family:'IBM Plex Mono',monospace">${costFmt}</span>
-                        <span style="color:var(--text-tertiary)">Input Tokens</span><span style="font-family:'IBM Plex Mono',monospace">${(data.input_tokens || 0).toLocaleString()}</span>
-                        <span style="color:var(--text-tertiary)">Output Tokens</span><span style="font-family:'IBM Plex Mono',monospace">${(data.output_tokens || 0).toLocaleString()}</span>
+                        <span style="color:var(--text-tertiary)">Latency</span><span style="font-family:'IBM Plex Mono',monospace">${iwFormatLatency(latency)}</span>
+                        <span style="color:var(--text-tertiary)">Cost${isEstimated ? ' (est.)' : ''}</span><span style="font-family:'IBM Plex Mono',monospace">${costFmt}</span>
+                        <span style="color:var(--text-tertiary)">Input Tokens${isEstimated ? ' (est.)' : ''}</span><span style="font-family:'IBM Plex Mono',monospace">${isEstimated ? '~' : ''}${(data.input_tokens || 0).toLocaleString()}</span>
+                        <span style="color:var(--text-tertiary)">Output Tokens${isEstimated ? ' (est.)' : ''}</span><span style="font-family:'IBM Plex Mono',monospace">${isEstimated ? '~' : ''}${(data.output_tokens || 0).toLocaleString()}</span>
                         ${data.model_size ? `<span style="color:var(--text-tertiary)">Model Size</span><span>${iwEscapeHtml(data.model_size)}</span>` : ''}
                     </div>
+                    ${isEstimated ? `<div class="iw-estimate-note">Token counts and cost are estimates. ITS algorithms make multiple internal LLM calls whose usage is not individually tracked. Latency is actual wall-clock time.</div>` : ''}
                 </div>
             </div>
             ${traceExpandable}


### PR DESCRIPTION
## Summary
- **Improved ITS token estimation** (#27): Added algorithm-aware overhead — Best-of-N now includes judge call tokens, process-based algorithms (beam search, particle filtering) include PRM scoring tokens. Uses actual candidate count from result objects where available.
- **Added `tokens_estimated` flag**: ITS results are marked `tokens_estimated=True`; baseline results (with actual litellm usage) remain `False`. Frontend shows `~` prefix and `(est.)` labels on estimated values, with an explanatory note in Performance Details.
- **Prominent generation time display** (#24): Response time is shown at the top of each interactive demo result pane with human-friendly formatting (e.g. `480ms`, `1.2s`). Guided demo badges also use the improved formatting.
- **Documented actual vs estimated metrics**: `ResultDetail` docstring and inline comments clearly explain which metrics are actual (latency) vs estimated (tokens, cost) and why (ITS algorithm internals don't surface per-call litellm usage).

## Test plan
- [ ] Start backend and run a Best-of-N comparison — verify ITS token count is higher than naive `baseline * budget` (judge overhead included)
- [ ] Run a beam search comparison — verify PRM overhead is reflected in token estimates
- [ ] Check response JSON for `tokens_estimated: true` on ITS results, `false`/absent on baselines
- [ ] Verify `~` prefix appears on ITS token/cost values in the interactive demo
- [ ] Verify "(est.)" label on Cost and Tokens in meta tags for ITS panes
- [ ] Expand Performance Details on an ITS pane — verify explanatory note is shown
- [ ] Verify generation time display appears prominently at top of each result pane
- [ ] Verify latency >= 1000ms shows as seconds (e.g. "1.2s") in both interactive and guided demos