### PR TITLE
Add 'How to use in Red Hat AI' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ cd its_hub
 pip install -e ".[dev]"
 ```
 
+## Using with Red Hat AI
+
+its_hub integrates with the Red Hat AI ecosystem. Install from the [Red Hat AI Python Index](https://access.redhat.com/articles/7137881), deploy as an IaaS gateway on OpenShift, or use directly with models served via the RHOAI vLLM serving runtime.
+
+See the full guide: [How to Use in Red Hat AI](https://ai-innovation.team/its_hub/#/red-hat-ai)
+
 ## Quick Start
 
 ### Example 1: Best-of-N with LLM Judge

--- a/demo_ui/frontend/app.js
+++ b/demo_ui/frontend/app.js
@@ -557,6 +557,14 @@ function renderAlgorithmTrace(trace, directDisplay = false) {
     `;
 }
 
+// Red Hat AI section toggle
+function toggleRhaiSection() {
+    const content = document.getElementById('rhaiContent');
+    const icon = document.getElementById('rhaiToggleIcon');
+    const isHidden = content.classList.toggle('hidden');
+    icon.textContent = isHidden ? '▼' : '▲';
+}
+
 // Wait for KaTeX to load
 function initializeApp() {
     checkSavedExperience();

--- a/demo_ui/frontend/index.html
+++ b/demo_ui/frontend/index.html
@@ -69,6 +69,46 @@
             </div>
         </div>
 
+        <!-- Red Hat AI Section -->
+        <div class="rhai-section">
+            <div class="rhai-header" role="button" tabindex="0" onclick="toggleRhaiSection()" onkeydown="if(event.key==='Enter')toggleRhaiSection()">
+                <h2 class="rhai-title">How to Use in Red Hat AI</h2>
+                <span class="rhai-toggle-icon" id="rhaiToggleIcon">▼</span>
+            </div>
+            <div class="rhai-content" id="rhaiContent">
+                <p class="rhai-intro">
+                    its_hub integrates with the Red Hat AI ecosystem. Install from the Red Hat AI Python Index, deploy as a gateway on OpenShift, or use directly with models served via RHOAI.
+                </p>
+                <div class="rhai-cards">
+                    <div class="rhai-card">
+                        <div class="rhai-card-icon">📦</div>
+                        <h3>Install from Red Hat AI Python Index</h3>
+                        <p>Install its_hub with a secure, Red Hat-built supply chain on RHOAI workbenches or RHEL AI.</p>
+                        <code class="rhai-code">pip install its_hub --extra-index-url https://download.devel.redhat.com/rel-eng/ai-python-index/</code>
+                    </div>
+                    <div class="rhai-card">
+                        <div class="rhai-card-icon">🚀</div>
+                        <h3>Deploy as IaaS Gateway</h3>
+                        <p>Run the FastAPI gateway on OpenShift. Any OpenAI-compatible client gets inference-time scaling by adding a <code>budget</code> parameter.</p>
+                        <code class="rhai-code">its-iaas --host 0.0.0.0 --port 8108</code>
+                    </div>
+                    <div class="rhai-card">
+                        <div class="rhai-card-icon">🖥️</div>
+                        <h3>Use with vLLM on OpenShift AI</h3>
+                        <p>Point its_hub at models served via the RHOAI vLLM serving runtime &mdash; Granite, Llama, or any supported model.</p>
+                        <code class="rhai-code">endpoint = "https://&lt;model-route&gt;/v1"</code>
+                    </div>
+                </div>
+                <div class="rhai-links">
+                    <a href="https://access.redhat.com/articles/7137881" target="_blank" rel="noopener">Red Hat AI Python Index</a>
+                    <span class="rhai-link-sep">|</span>
+                    <a href="https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/" target="_blank" rel="noopener">OpenShift AI Docs</a>
+                    <span class="rhai-link-sep">|</span>
+                    <a href="https://docs.redhat.com/en/documentation/red_hat_enterprise_linux_ai/" target="_blank" rel="noopener">RHEL AI Docs</a>
+                </div>
+            </div>
+        </div>
+
         <div class="landing-footer">
             Red Hat AI Innovation Team • Powered by its_hub
         </div>

--- a/demo_ui/frontend/main.css
+++ b/demo_ui/frontend/main.css
@@ -482,6 +482,145 @@ header {
     font-size: 14px;
 }
 
+/* Red Hat AI Section */
+.rhai-section {
+    max-width: 1200px;
+    width: 100%;
+    margin-top: 48px;
+    border: 2px solid var(--border-color);
+    background: var(--bg-secondary);
+}
+
+.rhai-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px 28px;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.rhai-header:hover {
+    background: var(--bg-tertiary);
+}
+
+.rhai-title {
+    font-family: 'Azeret Mono', monospace;
+    font-size: 16px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: var(--text-primary);
+    margin: 0;
+}
+
+.rhai-toggle-icon {
+    font-size: 14px;
+    color: var(--text-tertiary);
+    transition: transform 0.2s ease;
+}
+
+.rhai-content {
+    padding: 0 28px 28px;
+    border-top: 1px solid var(--border-color);
+}
+
+.rhai-content.hidden {
+    display: none;
+}
+
+.rhai-intro {
+    font-size: 14px;
+    color: var(--text-secondary);
+    line-height: 1.7;
+    margin: 20px 0 24px;
+}
+
+.rhai-cards {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 20px;
+    margin-bottom: 24px;
+}
+
+@media (max-width: 768px) {
+    .rhai-cards {
+        grid-template-columns: 1fr;
+    }
+}
+
+.rhai-card {
+    padding: 24px;
+    background: var(--bg-primary);
+    border: 2px solid var(--border-color);
+    transition: border-color 0.2s ease;
+}
+
+.rhai-card:hover {
+    border-color: var(--primary);
+}
+
+.rhai-card-icon {
+    font-size: 28px;
+    margin-bottom: 12px;
+}
+
+.rhai-card h3 {
+    font-family: 'Azeret Mono', monospace;
+    font-size: 13px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+    color: var(--text-primary);
+    margin-bottom: 10px;
+}
+
+.rhai-card p {
+    font-size: 13px;
+    color: var(--text-secondary);
+    line-height: 1.6;
+    margin-bottom: 14px;
+}
+
+.rhai-code {
+    display: block;
+    padding: 10px 12px;
+    background: var(--bg-tertiary);
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 11px;
+    color: var(--primary);
+    word-break: break-all;
+    line-height: 1.5;
+}
+
+.rhai-links {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    padding-top: 16px;
+    border-top: 1px solid var(--border-color);
+}
+
+.rhai-links a {
+    font-size: 13px;
+    color: var(--primary);
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.2s ease;
+}
+
+.rhai-links a:hover {
+    color: var(--primary-hover);
+    text-decoration: underline;
+}
+
+.rhai-link-sep {
+    color: var(--border-color);
+    font-size: 12px;
+}
+
 /* Main demo container - initially hidden */
 #demoContainer.hidden {
     display: none;

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -8,6 +8,7 @@
   - [Beam Search](algorithms.md#beam-search)
   - [Self-Consistency](algorithms.md#self-consistency)
 - [Planning Wrapper](PLANNING_WRAPPER.md)
+- [Using with Red Hat AI](red-hat-ai.md)
 - [Benchmarking](benchmarking.md)
 - [Development](development.md)
 - [Self-Consistency Improvements](self-consistency-projection-improvements.md)

--- a/docs/red-hat-ai.md
+++ b/docs/red-hat-ai.md
@@ -1,0 +1,333 @@
+# How to Use in Red Hat AI
+
+This guide explains how to use **its_hub** within the Red Hat AI ecosystem, covering installation from the Red Hat AI Python Index, deployment on OpenShift, and integration with Red Hat AI model serving.
+
+## Overview
+
+its_hub integrates with the Red Hat AI stack at multiple levels:
+
+```
+                        Red Hat AI Ecosystem
+┌─────────────────────────────────────────────────────────┐
+│                                                         │
+│  ┌──────────────┐    ┌──────────────┐    ┌───────────┐  │
+│  │  RHOAI       │    │  ITS Hub     │    │  vLLM     │  │
+│  │  Workbench   │───►│  (SDK or     │───►│  Serving  │  │
+│  │              │    │   Gateway)   │    │  Runtime  │  │
+│  └──────────────┘    └──────────────┘    └───────────┘  │
+│                                                         │
+│  Red Hat OpenShift AI  /  RHEL AI                       │
+└─────────────────────────────────────────────────────────┘
+```
+
+| Component | Role |
+|-----------|------|
+| **Red Hat OpenShift AI (RHOAI)** | ML platform for model serving, workbenches, and pipelines |
+| **RHEL AI** | RHEL-based environment for local AI model serving and fine-tuning |
+| **vLLM Serving Runtime** | High-performance model serving on OpenShift (included in RHOAI) |
+| **its_hub SDK** | Python library imported directly into your application code |
+| **its_hub IaaS Gateway** | FastAPI service providing an OpenAI-compatible API with inference-time scaling |
+
+---
+
+## Install from the Red Hat AI Python Index
+
+The [Red Hat AI Python Index](https://access.redhat.com/articles/7137881) provides Red Hat-built Python packages with a secure supply chain, supported on Red Hat OpenShift AI environments.
+
+### In an RHOAI Workbench
+
+From a terminal in your RHOAI workbench (UBI9 base image):
+
+```bash
+# Core installation (Best-of-N, Self-Consistency, cloud APIs)
+pip install its_hub \
+    --extra-index-url https://download.devel.redhat.com/rel-eng/ai-python-index/
+
+# With Process Reward Model support (Particle Filtering, Beam Search)
+pip install "its_hub[prm]" \
+    --extra-index-url https://download.devel.redhat.com/rel-eng/ai-python-index/
+```
+
+### In a RHEL AI Environment
+
+```bash
+pip install its_hub \
+    --extra-index-url https://download.devel.redhat.com/rel-eng/ai-python-index/
+```
+
+### Supported Variants
+
+The Red Hat AI Python Index provides packages for multiple platform targets:
+
+| Variant | Use Case |
+|---------|----------|
+| `cpu-ubi9` | CPU-only inference, cloud API usage |
+| `cuda12.9-ubi9` | NVIDIA GPU acceleration |
+| `rocm6.4-ubi9` | AMD GPU acceleration |
+
+### Verify Installation
+
+```python
+from its_hub.algorithms import BestOfN, SelfConsistency
+from its_hub.lms import OpenAICompatibleLanguageModel
+print("its_hub installed successfully")
+```
+
+---
+
+## Deploy as an IaaS Gateway on OpenShift
+
+The its_hub IaaS service can be deployed as a standalone gateway on OpenShift, providing an OpenAI-compatible API with inference-time scaling built in. Any application that speaks the OpenAI chat completions format can use it without code changes — just point to the gateway and add a `budget` parameter.
+
+### Build the Container Image
+
+Use the included devcontainer as a starting point:
+
+```bash
+# From the repo root
+podman build -t its-iaas:latest -f .devcontainer/Dockerfile .
+```
+
+Or create a minimal production Dockerfile:
+
+```dockerfile
+FROM registry.redhat.io/ubi9/python-311:latest
+
+WORKDIR /app
+RUN pip install its_hub --extra-index-url https://download.devel.redhat.com/rel-eng/ai-python-index/
+
+EXPOSE 8108
+CMD ["its-iaas", "--host", "0.0.0.0", "--port", "8108"]
+```
+
+### Deploy on OpenShift
+
+```yaml
+# its-iaas-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: its-iaas
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: its-iaas
+  template:
+    metadata:
+      labels:
+        app: its-iaas
+    spec:
+      containers:
+        - name: its-iaas
+          image: its-iaas:latest
+          ports:
+            - containerPort: 8108
+          env:
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: its-iaas-secrets
+                  key: openai-api-key
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: its-iaas
+spec:
+  selector:
+    app: its-iaas
+  ports:
+    - port: 8108
+      targetPort: 8108
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: its-iaas
+spec:
+  to:
+    kind: Service
+    name: its-iaas
+  port:
+    targetPort: 8108
+  tls:
+    termination: edge
+```
+
+```bash
+# Create secrets and deploy
+oc create secret generic its-iaas-secrets \
+    --from-literal=openai-api-key=sk-...
+
+oc apply -f its-iaas-deployment.yaml
+```
+
+### Configure the Gateway
+
+Once deployed, configure the algorithm via the `/configure` endpoint:
+
+```bash
+ITS_ROUTE=$(oc get route its-iaas -o jsonpath='{.spec.host}')
+
+curl -X POST "https://${ITS_ROUTE}/configure" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider": "litellm",
+    "endpoint": "auto",
+    "api_key": "your-api-key",
+    "model": "gpt-4o-mini",
+    "alg": "self-consistency",
+    "tool_vote": "tool_hierarchical"
+  }'
+```
+
+For full configuration options, see the [IaaS Service Guide](iaas-service.md).
+
+---
+
+## Use with Self-Hosted Models on OpenShift (vLLM Serving)
+
+Red Hat OpenShift AI includes a vLLM serving runtime for hosting models on-cluster. its_hub works directly with these model serving endpoints.
+
+### Set Up Model Serving in RHOAI
+
+1. In the RHOAI dashboard, create a **Single-Model Serving** instance
+2. Select the **vLLM** serving runtime
+3. Deploy your model (e.g., `ibm-granite/granite-3.3-8b-instruct`, `meta-llama/Llama-3.2-3B-Instruct`)
+4. Note the **Inference endpoint** URL from the dashboard
+
+### Connect its_hub to the Served Model
+
+```python
+from its_hub.lms import OpenAICompatibleLanguageModel
+from its_hub.algorithms import SelfConsistency
+
+# Point to your RHOAI model serving endpoint
+lm = OpenAICompatibleLanguageModel(
+    endpoint="https://<model-serving-route>/v1",  # From RHOAI dashboard
+    api_key="<serving-token>",                     # RHOAI auth token
+    model_name="ibm-granite/granite-3.3-8b-instruct",
+)
+
+# Use Self-Consistency for reliable tool calling
+sc = SelfConsistency(tool_vote="tool_hierarchical")
+result = sc.infer(
+    lm,
+    "What is the capital of France?",
+    budget=5,
+)
+print(result)
+```
+
+### Example Endpoint Configurations
+
+| Platform | Endpoint Format | API Key |
+|----------|----------------|---------|
+| RHOAI (in-cluster) | `http://<service-name>:8080/v1` | RHOAI serving token |
+| RHOAI (external route) | `https://<route-host>/v1` | RHOAI serving token |
+| RHEL AI (local) | `http://localhost:8100/v1` | `NO_API_KEY` |
+| vLLM standalone | `http://<host>:8100/v1` | `NO_API_KEY` or custom |
+
+### Using with Granite Models
+
+IBM Granite models are available through RHOAI and work well with its_hub:
+
+```python
+from its_hub.lms import OpenAICompatibleLanguageModel
+from its_hub.algorithms import BestOfN
+from its_hub.integration.reward_hub import LLMJudgeRewardModel
+
+# Granite model served via RHOAI
+lm = OpenAICompatibleLanguageModel(
+    endpoint="https://granite-serving.apps.cluster.example.com/v1",
+    api_key="<serving-token>",
+    model_name="ibm-granite/granite-3.3-8b-instruct",
+)
+
+# Use Best-of-N with the same model as judge
+judge = LLMJudgeRewardModel(
+    model="ibm-granite/granite-3.3-8b-instruct",
+    base_url="https://granite-serving.apps.cluster.example.com/v1",
+    criterion="overall_quality",
+    judge_type="groupwise",
+    api_key="<serving-token>",
+)
+
+scaling_alg = BestOfN(judge)
+result = scaling_alg.infer(lm, "Explain inference-time scaling", budget=4)
+print(result)
+```
+
+---
+
+## End-to-End Example on RHOAI
+
+This walkthrough covers the full workflow: serving a model, installing its_hub, and running inference-time scaling — all on Red Hat OpenShift AI.
+
+### 1. Serve a Model
+
+In the RHOAI dashboard:
+- Navigate to **Model Serving** > **Deploy Model**
+- Select **vLLM ServingRuntime**
+- Choose a model (e.g., `meta-llama/Llama-3.2-3B-Instruct`)
+- Set resource limits and deploy
+- Copy the inference endpoint URL once the model is ready
+
+### 2. Install its_hub in a Workbench
+
+Open a terminal in your RHOAI workbench:
+
+```bash
+pip install its_hub \
+    --extra-index-url https://download.devel.redhat.com/rel-eng/ai-python-index/
+```
+
+### 3. Run Inference-Time Scaling
+
+```python
+from its_hub.lms import OpenAICompatibleLanguageModel
+from its_hub.algorithms import SelfConsistency
+
+# Connect to your RHOAI-served model
+lm = OpenAICompatibleLanguageModel(
+    endpoint="https://llama-serving.apps.cluster.example.com/v1",
+    api_key="<your-rhoai-token>",
+    model_name="meta-llama/Llama-3.2-3B-Instruct",
+)
+
+# Self-Consistency: generate 5 responses, vote on the best answer
+sc = SelfConsistency()
+result = sc.infer(lm, "What is 15% of 240?", budget=5)
+print(f"Answer: {result}")
+```
+
+### 4. (Optional) Deploy as Gateway
+
+To make inference-time scaling available to other services on the cluster, deploy the IaaS gateway as described [above](#deploy-as-an-iaas-gateway-on-openshift). Other applications can then use the standard OpenAI client:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://its-iaas:8108/v1",
+    api_key="dummy-key"
+)
+
+response = client.chat.completions.create(
+    model="meta-llama/Llama-3.2-3B-Instruct",
+    messages=[{"role": "user", "content": "What is 15% of 240?"}],
+    extra_body={"budget": 5}
+)
+print(response.choices[0].message.content)
+```
+
+---
+
+## Further Reading
+
+- [Red Hat AI Python Index](https://access.redhat.com/articles/7137881) — Package index details and supported environments
+- [Red Hat OpenShift AI Documentation](https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/) — Platform setup and model serving
+- [RHEL AI Documentation](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux_ai/) — Local AI model serving on RHEL
+- [vLLM Serving Runtime](https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/2-latest/html/serving_models/serving-large-models_serving-large-models#configuring-a-vllm-model-serving-runtime_serving-large-models) — Configuring vLLM on OpenShift AI
+- [IaaS Service Guide](iaas-service.md) — Full its_hub gateway configuration reference


### PR DESCRIPTION
## Summary

- Add `docs/red-hat-ai.md` covering installation from the Red Hat AI Python Index, IaaS gateway deployment on OpenShift, vLLM serving integration on RHOAI, Granite model examples, and an end-to-end walkthrough
- Add collapsible "How to use in Red Hat AI" section to the demo UI landing page with three info cards (Python Index install, IaaS gateway, vLLM on OpenShift AI) and links to Red Hat AI documentation
- Add brief "Using with Red Hat AI" section to `README.md` with link to full docs
- Add new page to docs sidebar navigation

Closes #5

## Test plan

- [ ] Verify `docs/red-hat-ai.md` renders correctly in docsify at https://ai-innovation.team/its_hub/#/red-hat-ai
- [ ] Verify the collapsible Red Hat AI section on the demo landing page expands/collapses correctly
- [ ] Verify landing page layout is not disrupted on desktop and mobile
- [ ] Verify all external links (Red Hat AI Python Index, OpenShift AI docs, RHEL AI docs) resolve correctly
- [ ] Verify dark and light themes both render the new section properly